### PR TITLE
More mappy words

### DIFF
--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -31,7 +31,7 @@
     <h4>Tangram JS Library</h4>
 
     <ul>
-      <li><code><script type="text/javascript" src="https://www.nextzen.org/tangram/0.14/tangram.min.js"></script></code></li>
+      <li><code>&lt;script type="text/javascript" src="https://www.nextzen.org/tangram/0.14/tangram.min.js"&gt;&lt;/script&gt;</code></li>
     </ul>
 
     <h4>Basemap Resources</h4>

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -48,7 +48,7 @@
     <h4>See Also</h4>
 
     <ul>
-      <li>Read <a href="https://mapzen.com/blog/long-term-support-mapzen-maps/">Long-term support for Mapzen maps, vector &amp; terrain tiles</a> on the Mapzen blog (2019.01.30)</li>
+      <li>Read <a href="https://mapzen.com/blog/long-term-support-mapzen-maps/">Long-term support for Mapzen maps, vector &amp; terrain tiles</a> on the Mapzen blog (2019.01.30) and <a href="https://web.archive.org/web/20180130194727/https://mapzen.com/blog/long-term-support-mapzen-maps/">archive.org</a></li>
     </ul>
     
 </div>

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -53,5 +53,5 @@
     
 </div>
 
-<p>Nextzen is after <a href="https://mapzen.com">Mapzen</a>.</p>
+<p>Nextzen is after <a href="https://en.wikipedia.org/wiki/Mapzen">Mapzen</a>.</p>
 {% endblock %}

--- a/app/templates/apikey/mine.html
+++ b/app/templates/apikey/mine.html
@@ -42,7 +42,7 @@
 {% for key in current_user.api_keys.values() %}
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title">✍ API Key <code id="api_key">{{ key.api_key }}</code><button class="btn" data-clipboard-text="{{ key.api_key }}" data-toggle="tooltip" data-placement="bottom" data-trigger="click" title="Copied to clipboard!"><span class="glyphicon glyphicon-copy" aria-hidden="true"></span></button></h3>
+    <h3 class="panel-title">API Key <code id="api_key">{{ key.api_key }}</code><button class="btn" data-clipboard-text="{{ key.api_key }}" data-toggle="tooltip" data-placement="bottom" data-trigger="click" title="Copied to clipboard!"><span class="glyphicon glyphicon-copy" aria-hidden="true"></span></button></h3>
   </div>
   <div class="panel-body">
     <dl class="dl-horizontal">
@@ -71,7 +71,7 @@
       <dd><em>Allow all</em></dd>
       {% endif %}
     </dl>
-    <a class="btn btn-default" role="button" href="{{ url_for('apikey.show', apikey=key.api_key) }}">Edit this key</a>
+    <a class="btn btn-default" role="button" href="{{ url_for('apikey.show', apikey=key.api_key) }}">✍ Edit this key</a>
   </div>
 </div>
 {% else %}

--- a/app/templates/contact.html
+++ b/app/templates/contact.html
@@ -6,5 +6,5 @@
     <h3>Contact Us</h3>
 </div>
 
-<p>You can email us at <a href="mailto:admin@nextzen.org">admin@nextzen.org</a>.</p>
+<p>You can email us at <a href="mailto:hello@nextzen.org">hello@nextzen.org</a>.</p>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,14 +11,12 @@
 <div class="row marketing">
     <div class="col-lg-6">
         <h4>Miss Mapzen's Vector Tiles?</h4>
-        <p>Tilezen is the industrial strength open software that powered Mapzen's Vector Tiles.</p>
-
+        <p><a href="https://github.com/tilezen/">Tilezen</a> is the industrial strength open software that powered Mapzen's Vector Tiles.</p>
     </div>
 
     <div class="col-lg-6">
         <h4>Beautiful Basemaps</h4>
-        <p>From Bubble Wrap to Refill and Walkabout beautiful map styles pair with Tilezen's data schema.</p>
-
+        <p>From Bubble Wrap to Refill and Walkabout beautiful <a href="/about.html">map styles</a> pair with Tilezen's data schema.</p>
     </div>
 </div>
 


### PR DESCRIPTION
- Move edit icon out of static header to button on My Keys page
- Use hello@nextzen.org email
- Use < and > HTML codes to get Tangram snippet to display on About page
- Use more stable Wikipedia link for Mapzen on About page
- Add archive.org link for Mapzen's Nextzen blog post
- Link map styles to About page