### PR TITLE
Update the basemaps

### DIFF
--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -35,13 +35,15 @@
     <h4>Basemap Resources</h4>
 
     <ul>
-      <li><code>https://www.nextzen.org/carto/bubble-wrap-style/9/bubble-wrap-style.zip</code></li>
-      <li><code>https://www.nextzen.org/carto/cinnabar-style/9/cinnabar-style.zip</code></li>
-      <li><code>https://www.nextzen.org/carto/refill-style/11/refill-style.zip</code></li>
+      <li><code>https://www.nextzen.org/carto/bubble-wrap-style/10/bubble-wrap-style.zip</code></li>
+      <li><code>https://www.nextzen.org/carto/cinnabar-style/10/cinnabar-style.zip</code></li>
+      <li><code>https://www.nextzen.org/carto/refill-style/12/refill-style.zip</code></li>
       <li><code>https://www.nextzen.org/carto/tron-style/6/tron-style.zip</code></li>
-      <li><code>https://www.nextzen.org/carto/walkabout-style/7/walkabout-style.zip</code></li>
+      <li><code>https://www.nextzen.org/carto/walkabout-style/8/walkabout-style.zip</code></li>
       <li><code>https://www.nextzen.org/carto/sdk-default-style/1.1/sdk-default-style.zip</code></li>
     </ul>
+
+    <p><i>Basemaps last major update: 2018-12-05</i></p>
 
     <h4>TileJSON Endpoints</h4>
 


### PR DESCRIPTION
- Update major versions of Bubble Wrap, Refill, Walkabout, and Cinnabar to reflect support for v1.5 Tilezen schema (mostly road shields).