### PR TITLE
Add config options to disable new user signups and API key creation

### DIFF
--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -16,10 +16,16 @@ from . import admin_bp
 from ..storage import ApiKey, User, validate_allowed_origins
 from flask_login import current_user, login_required
 
+
+# Return true if the current user is an admin
+def current_user_is_admin():
+    return current_user.social_id in current_app.config.get('ADMIN_WHITELIST')
+
+
 @admin_bp.route('/admin')
 @login_required
 def index():
-    if current_user.social_id not in current_app.config.get('ADMIN_WHITELIST'):
+    if not current_user_is_admin():
         return redirect(url_for('apikey.mine'))
 
     return render_template('admin/index.html')
@@ -27,7 +33,7 @@ def index():
 @admin_bp.route('/admin/by_key', methods=['POST'])
 @login_required
 def get_by_key():
-    if current_user.social_id not in current_app.config.get('ADMIN_WHITELIST'):
+    if not current_user_is_admin():
         return redirect(url_for('apikey.mine'))
 
     apikey = request.form.get('key')
@@ -43,7 +49,7 @@ def get_by_key():
 @admin_bp.route('/admin/keys/<apikey>', methods=['GET', 'POST'])
 @login_required
 def show_key(apikey):
-    if current_user.social_id not in current_app.config.get('ADMIN_WHITELIST'):
+    if not current_user_is_admin():
         return redirect(url_for('apikey.mine'))
 
     k = ApiKey.get_by_api_key(apikey)
@@ -128,7 +134,7 @@ def show_key(apikey):
 @admin_bp.route('/admin/users/<userid>', methods=['GET', 'POST'])
 @login_required
 def show_user(userid):
-    if current_user.social_id not in current_app.config.get('ADMIN_WHITELIST'):
+    if not current_user_is_admin():
         return redirect(url_for('apikey.mine'))
 
     u = User.get_by_user_id(userid)

--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -82,6 +82,10 @@ def oauth_callback(provider):
 
     user = User.get_by_social_id(social_id)
     if not user:
+        if current_app.config.get('DISABLE_USER_SIGNUP'):
+            flash("Sorry, new user signups are disabled.", 'error')
+            return redirect(url_for('auth.login'))
+
         user = User(
             email=email,
             social_id=social_id,
@@ -98,7 +102,7 @@ def oauth_callback(provider):
                 resp = requests.post(webhook_url, json={"text": "New user `%s` (`%s`) joined!" % (social_id, email)})
                 resp.raise_for_status()
             except:
-                current_app.logger.exception("Coudln't post to slack for some reason")
+                current_app.logger.exception("Couldn't post to slack for some reason")
     login_user(user, True)
 
     return redirect(url_for('apikey.mine'))

--- a/app/config.py
+++ b/app/config.py
@@ -32,6 +32,11 @@ class Config:
 
     ADMIN_WHITELIST = os.environ.get('ADMIN_WHITELIST', '').split(',')
 
+    # Disable API key creation for everyone but admins
+    DISABLE_USER_API_KEY_CREATION = os.environ.get('DISABLE_USER_API_KEY_CREATION', "false") == "true"
+    # Disable new user signups
+    DISABLE_USER_SIGNUP = os.environ.get('DISABLE_USER_SIGNUP', "false") == "true"
+
     @staticmethod
     def init_app(app):
         pass

--- a/app/templates/apikey/mine.html
+++ b/app/templates/apikey/mine.html
@@ -79,6 +79,8 @@
 
 {% if current_user.admin_locked %}
 <p>⚠️ Your account has been locked by an administrator, so you cannot create more API keys. Please <a href="mailto:hello@nextzen.org">contact us</a> if you have questions.</p>
+{% elif disable_api_key_creation %}
+<p>⚠️ API key creation has been disabled by an administrator. Please <a href="mailto:hello@nextzen.org">contact us</a> if you have questions.</p>
 {% else %}
 <form method="POST" action="{{ url_for('apikey.create') }}">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>


### PR DESCRIPTION
This adds configuration to disable API key creation and to disable new user signups.

Users allowlisted as admins are still allowed to create API keys.

cc @nvkelso 